### PR TITLE
Use node-gyp compatible version of Python in runner for test workflow

### DIFF
--- a/.github/workflows/test-typescript-npm.yml
+++ b/.github/workflows/test-typescript-npm.yml
@@ -3,6 +3,10 @@ name: Test TypeScript
 env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 10.x
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
+  # Using newest version documented as supported by node-gyp dependency:
+  # https://github.com/nodejs/node-gyp/tree/v7.1.2#installation
+  PYTHON_VERSION: 3.8
 
 on:
   push:
@@ -59,6 +63,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
The [`node-gyp`](https://github.com/nodejs/node-gyp) dependency of this project uses a Python script.

Previously, the test GitHub Actions workflow was not configured to install a specific version of Python, so whichever version of Python 3.x that was pre-installed on the GitHub Actions runner machine was used.

The documentation for the `node-gyp@7.1.2` version used by this project indicates the newest supported Python version is 3.8:

https://github.com/nodejs/node-gyp/tree/v7.1.2#installation

Clearly newer versions did work because the workflow has been [running with Python 3.10](https://github.com/actions/runner-images/blob/macOS-11/20221023.1/images/macos/macos-11-Readme.md#language-and-runtime). However, the `macos-latest` runner was [updated to using Python 3.11](https://github.com/actions/runner-images/commit/ee7ad8fcb76108a6739a5a237be219b99b8aec27) and the script now fails when `npm install` is ran in the project:

https://github.com/arduino/arduino-serial-plotter-webapp/actions/runs/3428463267/jobs/5714559323#step:4:122

```text
ValueError: invalid mode: 'rU' while trying to load binding.
```

The solution is to install a specific version of Python for use in the runner. It seems safest to use the newest version explicitly stated as supported by the `node-gyp@7.1.2` documentation, so Python 3.8 is installed.