### PR TITLE
Added dropdown to Legend for dataPointThreshold

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ export default function App() {
           serialPort: serialPortExtracted,
           connected,
           generate,
+          dataPointThreshold,
         } = message.data.monitorUISettings || {};
 
         let updateTitle = false;
@@ -130,6 +131,10 @@ export default function App() {
               typeof generate === "undefined"
                 ? prevConfig?.monitorUISettings?.generate
                 : generate,
+            dataPointThreshold:
+              typeof dataPointThreshold === "undefined"
+                ? prevConfig?.monitorUISettings?.dataPointThreshold
+                : dataPointThreshold,
           },
         }));
 
@@ -195,6 +200,9 @@ export default function App() {
           serialPort: urlParams.get("serialPort") || "/serial/port/address",
           connected: urlParams.get("connected") === "true",
           generate: urlParams.get("generate") === "true",
+          dataPointThreshold: parseInt(
+            urlParams.get("dataPointThreshold") || "50"
+          ),
         },
       };
 

--- a/src/ChartPlotter.tsx
+++ b/src/ChartPlotter.tsx
@@ -43,7 +43,9 @@ function _Chart(
   const [connected, setConnected] = useState(
     config?.monitorUISettings?.connected
   );
-  const [dataPointThreshold] = useState(50);
+  const [dataPointThreshold, setDataPointThreshold] = useState<number>(
+    config?.monitorUISettings?.dataPointThreshold || 50
+  );
   const [cubicInterpolationMode, setCubicInterpolationMode] = useState<
     "default" | "monotone"
   >(config?.monitorUISettings?.interpolate ? "monotone" : "default");
@@ -230,6 +232,8 @@ function _Chart(
           wsSend={wsSend}
           setPause={togglePause}
           setInterpolate={setInterpolate}
+          dataPointThreshold={dataPointThreshold}
+          setDataPointThreshold={setDataPointThreshold}
         />
         <div className="canvas-container">
           <Line data={initialData} ref={chartRef as any} options={opts} />

--- a/src/Legend.tsx
+++ b/src/Legend.tsx
@@ -136,8 +136,8 @@ export function Legend({
         )}
       </div>
       <div className="actions">
-        <label className="interpolate">
-          <span>Number of Datapoints</span>
+        <label className="datapoints">
+          <span>Datapoints</span>
           <Select
             className="singleselect datapointscount"
             classNamePrefix="select"

--- a/src/Legend.tsx
+++ b/src/Legend.tsx
@@ -4,6 +4,7 @@ import { LegendItem } from "./LegendItem";
 import { MonitorSettings, PluggableMonitor } from "./utils";
 import { Scrollbars } from "react-custom-scrollbars";
 import Switch from "react-switch";
+import Select from "react-select";
 import classNames from "classnames";
 
 export function Legend({
@@ -14,16 +15,20 @@ export function Legend({
   wsSend,
   setPause,
   setInterpolate,
+  dataPointThreshold,
+  setDataPointThreshold,
 }: {
   chartRef: ChartJSOrUndefined<"line">;
   pause: boolean;
   config: Partial<MonitorSettings>;
   cubicInterpolationMode: "monotone" | "default";
+  dataPointThreshold: number;
   wsSend: (
     clientCommand: PluggableMonitor.Protocol.ClientCommandMessage
   ) => void;
   setPause: (pause: boolean) => void;
   setInterpolate: (interpolate: boolean) => void;
+  setDataPointThreshold: (dataPointThreshold: number) => void;
 }): React.ReactElement {
   const scrollRef = useRef<Scrollbars>(null);
 
@@ -131,6 +136,41 @@ export function Legend({
         )}
       </div>
       <div className="actions">
+        <label className="interpolate">
+          <span>Number of Datapoints</span>
+          <Select
+            className="singleselect datapointscount"
+            classNamePrefix="select"
+            value={{
+              value: dataPointThreshold,
+              label: dataPointThreshold.toString(),
+            }}
+            name="datapointscount"
+            options={[
+              { value: 50, label: "50" },
+              { value: 100, label: "100" },
+              { value: 200, label: "200" },
+              { value: 500, label: "500" },
+              { value: 1000, label: "1000" },
+              { value: 5000, label: "5000" },
+            ]}
+            menuPlacement="top"
+            onChange={(event) => {
+              if (event) {
+                setDataPointThreshold(event.value);
+                wsSend({
+                  command:
+                    PluggableMonitor.Protocol.ClientCommand.CHANGE_SETTINGS,
+                  data: {
+                    monitorUISettings: {
+                      dataPointThreshold: event.value,
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </label>
         <label className="interpolate">
           <span>Interpolate</span>
           <Switch

--- a/src/index.scss
+++ b/src/index.scss
@@ -223,6 +223,16 @@ body {
         }
       }
 
+      .datapoints {
+        display: flex;
+        align-items: center;
+  
+        span {
+          margin-right: 10px;
+          font-size: 14px;
+        }
+      }
+
       .pause-button {
         width: 75px;
         text-align: center;
@@ -337,6 +347,10 @@ body {
       background-color: var(--select-option-focused);
     }
   }
+}
+
+.datapointscount{
+  min-width:50px;
 }
 
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,7 @@ interface MonitorModelState {
   serialPort: string;
   connected: boolean;
   generate?: boolean;
+  dataPointThreshold: number;
 }
 
 export interface MonitorSettings {


### PR DESCRIPTION
Hey everyone,
I stumbled upon [arduino-ide/#803](https://github.com/arduino/arduino-ide/issues/803) which has been unresolved since Feb 2, 2022. This pull request addresses that issue. 

I added a small dropdown to the Legend component which allows modification of the `dataPointThreshold`, which is used to determine the maximum number of datapoints that will be shown in the serial plotter.

This pull request introduces:
- A new URL parameter [`dataPointThreshold`](https://github.com/ignis-sec/arduino-serial-plotter-webapp/blob/50cdc23b1528d730e7a7094bc214ae7650f817a3/src/App.tsx#L203) that sets the initial value of the variable. (Default set to 50, which was the previous hardcoded value)
- [A new dropdown](https://github.com/ignis-sec/arduino-serial-plotter-webapp/blob/50cdc23b1528d730e7a7094bc214ae7650f817a3/src/Legend.tsx#L140) in the Legend component for the `dataPointThreshold` attribute.
- [A new setter hook](https://github.com/ignis-sec/arduino-serial-plotter-webapp/blob/50cdc23b1528d730e7a7094bc214ae7650f817a3/src/ChartPlotter.tsx#L46) in the ChartPlotter component for the `dataPointThreshold` attribute.
- [A new attribute under MonitorModelState](https://github.com/ignis-sec/arduino-serial-plotter-webapp/blob/50cdc23b1528d730e7a7094bc214ae7650f817a3/src/utils.ts#L35) for the attribute.

Tested with the master branch of [arduino/arduino-ide](https://github.com/arduino/arduino-ide), found no potential issues.

![image](https://github.com/arduino/arduino-serial-plotter-webapp/assets/16636092/b11e0232-7e58-402a-b6c2-2034a4d66058)
![image](https://github.com/arduino/arduino-serial-plotter-webapp/assets/16636092/0b33f4ca-2260-49f9-bd0d-e2298e6c0119)
![image](https://github.com/arduino/arduino-serial-plotter-webapp/assets/16636092/d9289d82-edae-41c2-9fe8-2011dda6b987)
![image](https://github.com/arduino/arduino-serial-plotter-webapp/assets/16636092/97cbdaf1-9a96-4254-bc1f-636456fec30d)



